### PR TITLE
Avoid abort of a program if the matrix `L1` in the function `get_beta_req` is not invertible

### DIFF
--- a/src/computeQPtilde.hpp
+++ b/src/computeQPtilde.hpp
@@ -36,6 +36,7 @@ static unsigned int get_beta_req(const BaseEncoding &y0x0, const BaseEncoding &y
     NTL::mat_GF2 L0 = l0.getA().to_mat_GF2();
     NTL::mat_GF2 L1 = l1.getA().to_mat_GF2();
     L.SetDims(SIZE_MATRIX, SIZE_MATRIX);
+    if (NTL::IsZero(NTL::determinant(L1))) return 0;
     NTL::inv(L1, L1);
     mul(L, L1, L0);
 


### PR DESCRIPTION
Avoid abort of a program if the matrix `L1` in the function `get_beta_req` is not invertible

This happens because "[by default, [library] NTL reverts to its old error handling method: abort with an error message][libntl]".
Without this change, if `L1` is not invertible, then `NTL::inv(L1, L1)` calls `abort`, which makes the whole program (python script) to exit.

[libntl]: https://libntl.org/doc/tour-impl.html